### PR TITLE
change sqlite3 import url

### DIFF
--- a/dbjob.go
+++ b/dbjob.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"log"
 
-	"code.google.com/p/go-sqlite/go1/sqlite3"
+	"github.com/mxk/go-sqlite/sqlite3"
 )
 
 const batchSize int = 100


### PR DESCRIPTION
Changed the import url to reflect the that the dependency moved from google code to github.

This allows the latest project to be compiled with `go get github.com/rselph/sumcheck/`, since no binaries are available for download.